### PR TITLE
Trebuchet: re-enable rotation by default on tablets

### DIFF
--- a/res/values-sw600dp/config.xml
+++ b/res/values-sw600dp/config.xml
@@ -1,6 +1,5 @@
 <resources>
     <bool name="is_tablet">true</bool>
-    <bool name="allow_rotation">true</bool>
 
 <!-- DragController -->
     <integer name="config_flingToDeleteMinVelocity">-1000</integer>

--- a/res/values-sw600dp/preferences_defaults.xml
+++ b/res/values-sw600dp/preferences_defaults.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="preferences_interface_allow_rotation">true</bool>
+</resources>


### PR DESCRIPTION
allow rotation pref got moved to overlay panel on commit 72f2ccb08f297836d18b61d5d80de9fcd7a69042
but it wasn't moved on sw600dp overlay.

Change-Id: Idbdef7804d50d4144d0a1fb5e6ea7dd6c7f5f257
