### PR TITLE
Ignore tap below scrubber in the app container padding area

### DIFF
--- a/src/com/android/launcher3/allapps/AllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/AllAppsContainerView.java
@@ -485,7 +485,23 @@ public class AllAppsContainerView extends BaseContainerView implements DragSourc
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        return handleTouchEvent(ev);
+        int y = (int) ev.getY();
+        int[] location = new int[2];
+        int height = 0;
+
+        // Ignore the touch if it is below scrubber (if enabled) or below app recycler view
+        if (useScroller() && useScrubber()) {
+            mScrubber.getLocationInWindow(location);
+            height = mScrubber.getHeight();
+        } else {
+            mAppsRecyclerView.getLocationInWindow(location);
+            height = mAppsRecyclerView.getHeight();
+        }
+        if (y >= location[1] + height) {
+            return true;
+        } else {
+            return handleTouchEvent(ev);
+        }
     }
 
     @SuppressLint("ClickableViewAccessibility")


### PR DESCRIPTION
When user taps on the padding area of all apps container below
the scrubber, the tap should be ignored. Before this patch, the
tap was sent back to parent view, which led to scrolling of the
background wallpaper. Now the tap is ignored.

Change-Id: Ic8840c9eafaf254d2bfbffe556f3dc7ab20fdccc
Issue-Id: CyanogenOS/CYNGNOS-1933
