### PR TITLE
Trebuchet: send metrics directly when possible

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,6 +28,7 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
     android-support-v7-recyclerview \
     org.cyanogenmod.platform.internal
 
+LOCAL_STATIC_JAVA_AAR_LIBRARIES := ambientsdk
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src) \
     $(call all-java-files-under, WallpaperPicker/src) \
@@ -43,7 +44,8 @@ LOCAL_PROTOC_OPTIMIZE_TYPE := nano
 LOCAL_PROTOC_FLAGS := --proto_path=$(LOCAL_PATH)/protos/
 LOCAL_AAPT_FLAGS := \
     --auto-add-overlay \
-    --extra-packages android.support.v7.recyclerview
+    --extra-packages android.support.v7.recyclerview \
+    --extra-packages com.cyanogen.ambient
 
 #LOCAL_SDK_VERSION := current
 LOCAL_PACKAGE_NAME := Trebuchet

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -237,5 +237,8 @@
 
         <meta-data android:name="android.nfc.disable_beam_default"
                        android:value="true" />
+
+        <meta-data android:name="com.cyanogen.ambient.analytics.key"
+                   android:value="DScKo29EpMBx1833F7ln1811KFPf14UT"/>
     </application>
 </manifest>

--- a/src/com/android/launcher3/LauncherApplication.java
+++ b/src/com/android/launcher3/LauncherApplication.java
@@ -20,10 +20,14 @@ import android.app.Application;
 
 import com.android.launcher3.stats.LauncherStats;
 import com.android.launcher3.stats.internal.service.AggregationIntentService;
+import com.cyanogen.ambient.analytics.AnalyticsServices;
+import com.cyanogen.ambient.analytics.Event;
+import com.cyanogen.ambient.common.api.AmbientApiClient;
 
 public class LauncherApplication extends Application {
 
     private static LauncherStats sLauncherStats = null;
+    private AmbientApiClient mClient;
 
     /**
      * Get the reference handle for LauncherStats commands
@@ -37,8 +41,18 @@ public class LauncherApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        mClient = new AmbientApiClient.Builder(this)
+                .addApi(AnalyticsServices.API)
+                .build();
+        mClient.connect();
         sLauncherStats = LauncherStats.getInstance(this);
         AggregationIntentService.scheduleService(this);
+    }
+
+    public void sendEvent(Event event) {
+        if (mClient.isConnected()) {
+            AnalyticsServices.AnalyticsApi.sendEvent(mClient, event);
+        }
     }
 
 }


### PR DESCRIPTION
Use the SDK directly instead of relying on an external package.

Still relies on C-Apps Core to send.

Reverts the revert and fixes the issue (missing aapt flag overlay)
This reverts commit d20f7796e45dcae0e619d3bb76a3a89674705702.

Ticket: CYNGNOS-2545
Change-Id: I9445cadc429c3158cabb6a7d07e016f6fe3dac19
