### PR TITLE
Prevent widget previews from showing empty images.

### DIFF
--- a/src/com/android/launcher3/widget/WidgetCell.java
+++ b/src/com/android/launcher3/widget/WidgetCell.java
@@ -183,7 +183,7 @@ public class WidgetCell extends LinearLayout implements OnLayoutChangeListener {
 
     public void ensurePreview() {
         if (mActiveRequest != null) {
-            return;
+            mActiveRequest.cleanup();
         }
         int[] size = getPreviewSize();
         if (DEBUG) {
@@ -226,5 +226,9 @@ public class WidgetCell extends LinearLayout implements OnLayoutChangeListener {
             return getTag().toString();
         }
         return "";
+    }
+
+    public PreviewLoadRequest getActiveRequest() {
+        return mActiveRequest;
     }
 }

--- a/src/com/android/launcher3/widget/WidgetsContainerView.java
+++ b/src/com/android/launcher3/widget/WidgetsContainerView.java
@@ -246,7 +246,7 @@ public class WidgetsContainerView extends BaseContainerView
 
             int[] previewSizeBeforeScale = new int[1];
             preview = getWidgetPreviewLoader().generateWidgetPreview(mLauncher,
-                    createWidgetInfo.info, maxWidth, null, previewSizeBeforeScale);
+                    createWidgetInfo.info, maxWidth, null, previewSizeBeforeScale, null);
 
             if (previewSizeBeforeScale[0] < icon.getWidth()) {
                 // The icon has extra padding around it.


### PR DESCRIPTION
When scrolling through the widget drawer, we submit multiple
AsyncTasks to load and display preview images. On certain
devices, attempting to load these images from
AppWidgetManagerCompat (when we are generating previews for
the first time) on a multi-threaded executor can cause us
to receive empty images. To avoid this, we allow preview
loading from the cache on a multi-threaded executor, but
defer preview generation to a single-threaded executor.

Additionally, the read and write db methods were not using
the same ComponentName output (flattenToString vs
flattenToSimpleString), which was resulting in consistent
cache misses that forced unnecessary preview regeneration.
This has been unified so we properly load from the cache.

Change-Id: I3a90cf88fed531713e5d2df876f4ede822f7d569
issue-id: FEIJ-346
