### PR TITLE
Trebuchet: Rebind QSB in finishBindingItems

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -4575,6 +4575,7 @@ public class Launcher extends Activity
         mWorkspace.stripEmptyScreens();
 
         sRemoteFolderManager.bindFinished();
+        bindSearchProviderChanged();
     }
 
     private void sendLoadingCompleteBroadcastIfNecessary() {


### PR DESCRIPTION
Sometimes the GMS QSB doesn't bind properly. Especially
after going through OOBE without network.

Issue-id: CYNGNOS-2833

Change-Id: Ib64fee898b6f55d14f35fe7efc5c36b090422d36
